### PR TITLE
Updated about page with new governance board info

### DIFF
--- a/app/views/static_pages/about.html.slim
+++ b/app/views/static_pages/about.html.slim
@@ -145,12 +145,6 @@ div
     br
     br
 
-    a href='https://www.jhsph.edu/faculty/directory/profile/1695/kay-dickersin' target='_blank' Kay Dickersin, MA, PhD
-    br
-    'Professor and Director, Cochrane Eyes and Vision, Johns Hopkins University, Baltimore, MD, USA
-    br
-    br
-
     a href='http://annals.org/aim/pages/biography' target='_blank' Christine Laine, MD, MPH
     br
     'Editor-in-Chief, Annals of Internal Medicine, American College of Physicians, Philadelphia, PA, USA
@@ -201,6 +195,12 @@ div
     br
 
     b Former Members (with current affiliations):
+    br
+    br
+
+    a href='https://www.jhsph.edu/faculty/directory/profile/1695/kay-dickersin' target='_blank' Kay Dickersin, MA, PhD
+    br
+    'Professor Emeritus and Former Director, Cochrane Eyes and Vision, Johns Hopkins University, Baltimore, MD, USA
     br
     br
 


### PR DESCRIPTION
Made following changes to the About page:

- Under the SRDR Governance Board, moved “Kay Dickersin, MA, PhD” from “Current Members” to “Former Members (with current affiliations)” and updated the affiliation information.