### PR TITLE
add filetypes info box for analytic/conceptual framework pictures upload

### DIFF
--- a/app/views/sd_meta_data/form/dynamic_fields/_sd_analytic_framework_fields.html.slim
+++ b/app/views/sd_meta_data/form/dynamic_fields/_sd_analytic_framework_fields.html.slim
@@ -2,7 +2,18 @@
   div class="text-right"
     = link_to_remove_association "remove framework", f, data: { confirm: "This will remove associated descriptions and pictures.  Are you sure?" }
   = f.input :name, label: 'Description', input_html: { oninput: 'this.style.height = "";this.style.height = this.scrollHeight + "px"' }
-  = f.input :pictures, as: :file, label: 'Pictures', input_html: { multiple: true, id: "#{dom_id(f.object)}", class: 'hide' }
+  = f.input :pictures, as: :file, label: false, input_html: { multiple: true, id: "#{dom_id(f.object)}", class: 'hide' }
+  div style="margin-bottom: 4px;"
+    span class="text-bold"
+      strong style="font-size: 12px; color: #333;" Pictures
+    span.import-tooltip-icon style="margin: 0 6px 0 3px;" data-open="import-tooltip-content"
+      i.fi-info style="color:#28b0f3;font-size:20px;"
+    .reveal#import-tooltip-content data-reveal="" style="font-size:large;line-height:25px;"
+      | You can upload the following file formats:
+      ul style="padding-top:15px;font-size:large;line-height:25px;"
+        li JPG
+        li GIF
+        li PNG
   label.button.file-picker for="#{dom_id(f.object)}"
     | Choose File
   - f.object.pictures.each do |picture|


### PR DESCRIPTION
- add missing tool tip to show user which file types can be uploaded for Analytic/Conceptual Framework field