### PR TITLE
Consolidation tool results section bugfixes

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -596,5 +596,9 @@ textarea {
 }
 
 .row {
-  max-width: 100%;
+  max-width: max(90%, 1200px);
+}
+
+.grid-container {
+  max-width: unset;
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -602,3 +602,7 @@ textarea {
 .grid-container {
   max-width: unset;
 }
+
+textarea {
+  min-height: 1.5em;
+}

--- a/app/assets/stylesheets/result_statistic_sections.scss
+++ b/app/assets/stylesheets/result_statistic_sections.scss
@@ -6,6 +6,12 @@
   font-weight: bold;
 }
 
+table.consolidated-data-table {
+  tr {
+    height: 2em;
+  }
+}
+
 form.dirty {
   input, textarea {
     background-color: lightyellow !important;

--- a/app/controllers/result_statistic_sections_controller.rb
+++ b/app/controllers/result_statistic_sections_controller.rb
@@ -27,8 +27,16 @@ class ResultStatisticSectionsController < ApplicationController
   def update
     respond_to do |format|
       if @result_statistic_section.update(result_statistic_section_params)
-        format.html { redirect_to edit_result_statistic_section_path(@result_statistic_section),
-                      notice: t('success') }
+        format.html do |format|
+          if params[:result_statistic_section].has_key? :extraction_ids
+            redirect_to consolidate_result_statistic_section_path(@result_statistic_section, 
+              extraction_ids: params[:result_statistic_section][:extraction_ids]),
+              notice: t('success')
+          else
+            redirect_to edit_result_statistic_section_path(@result_statistic_section),
+                    notice: t('success')
+          end
+        end
         format.json { render :show, status: :ok, location: @result_statistic_section }
         format.js { }
       else
@@ -86,6 +94,9 @@ class ResultStatisticSectionsController < ApplicationController
   def manage_measures
     respond_to do |format|
       format.js do
+        if params[:extraction_ids].present?
+          @extraction_ids = params[:extraction_ids]
+        end
         @result_statistic_section = ResultStatisticSection.find(params[:rss_id])
         @result_statistic_section.result_statistic_sections_measures.build.build_measure
         @options = @result_statistic_section

--- a/app/models/concerns/consolidation_helper.rb
+++ b/app/models/concerns/consolidation_helper.rb
@@ -500,11 +500,16 @@ module ConsolidationHelper
                     eefps_t1 = t1_id.present? ? linked_eefps.extractions_extraction_forms_projects_sections_type1s.select{|x| x.type1_id == t1_id.to_i and x.type1_type_id == t1_type_id_i}.first : nil
                     #we want  to change find_or_create_by into  find_by asap
                     eefps_qrcf = eefps.extractions_extraction_forms_projects_sections_question_row_column_fields.select{|x| x.extractions_extraction_forms_projects_sections_type1_id == eefps_t1&.id and x.question_row_column_field_id == qrcf_id.to_i}.first
+                    if eefps_qrcf.blank?
+                      eefps_qrcf = ExtractionsExtractionFormsProjectsSectionsQuestionRowColumnField.create(extractions_extraction_forms_projects_section: eefps, extractions_extraction_forms_projects_sections_type1_id: eefps_t1&.id, question_row_column_field_id: qrcf_id.to_i)
+                    end
+
                     if eefps_qrcf.records.blank?
-                      record = Record.create(recordable: eefps_qrcf, name: record_name.dup )
+                      record = Record.create( recordable: eefps_qrcf )
                     else
                       record = eefps_qrcf.records.first
                     end
+
                     if record_name.present? and record.name != record_name
                       record.update( name: record_name.dup )
                     end

--- a/app/models/extraction.rb
+++ b/app/models/extraction.rb
@@ -64,19 +64,20 @@ class Extraction < ApplicationRecord
 #  end
 
   def ensure_extraction_form_structure
-    self.project.extraction_forms_projects.includes([:extraction_forms_projects_sections, :extraction_form]).each do |efp|
-      efp.extraction_forms_projects_sections.includes([:link_to_type1]).each do |efps|
-        ExtractionsExtractionFormsProjectsSection.find_or_create_by!(
-          extraction: self,
-          extraction_forms_projects_section: efps,
-          link_to_type1: efps.link_to_type1.nil? ?
-            nil :
-            ExtractionsExtractionFormsProjectsSection.find_or_create_by!(
-              extraction: self,
-              extraction_forms_projects_section: efps.link_to_type1
-            )
-        )
-      end
+    # self.project.extraction_forms_projects.includes([:extraction_forms_projects_sections, :extraction_form]).each do |efp|
+    # NOTE This method assumes that self is not a mini-extraction
+    efp = self.project.extraction_forms_projects.includes([:extraction_forms_projects_sections, :extraction_form]).first
+    efp.extraction_forms_projects_sections.includes([:link_to_type1]).each do |efps|
+      ExtractionsExtractionFormsProjectsSection.find_or_create_by!(
+        extraction: self,
+        extraction_forms_projects_section: efps,
+        link_to_type1: efps.link_to_type1.nil? ?
+          nil :
+          ExtractionsExtractionFormsProjectsSection.find_or_create_by!(
+            extraction: self,
+            extraction_forms_projects_section: efps.link_to_type1
+          )
+      )
     end
   end
 

--- a/app/models/tps_arms_rssm.rb
+++ b/app/models/tps_arms_rssm.rb
@@ -31,17 +31,25 @@ class TpsArmsRssm < ApplicationRecord
   delegate :result_statistic_section,                      to: :result_statistic_sections_measure
 
   def self.find_record_by_extraction(extraction, a, result_statistic_section, tp, rssm)
-    _eefps_arm       = extraction.extractions_extraction_forms_projects_sections.find_by!(extraction_forms_projects_section: a.extractions_extraction_forms_projects_section.extraction_forms_projects_section)
-    _eefps_outcome   = extraction.extractions_extraction_forms_projects_sections.find_by!(extraction_forms_projects_section: result_statistic_section.population.extractions_extraction_forms_projects_sections_type1.extractions_extraction_forms_projects_section.extraction_forms_projects_section)
-    _eefpst1_arm     = _eefps_arm.extractions_extraction_forms_projects_sections_type1s.find_by!(type1: a.type1)
-    _eefpst1_outcome = _eefps_outcome.extractions_extraction_forms_projects_sections_type1s.find_by!(type1: result_statistic_section.population.extractions_extraction_forms_projects_sections_type1.type1)
-    _eefpst1r        = _eefpst1_outcome.extractions_extraction_forms_projects_sections_type1_rows.find_by!(population_name: result_statistic_section.population.population_name)
-    _eefpst1rc       = _eefpst1r.extractions_extraction_forms_projects_sections_type1_row_columns.find_by!(timepoint_name: tp.timepoint_name)
-    _rss             = _eefpst1r.result_statistic_sections.find_by!(result_statistic_section_type: result_statistic_section.result_statistic_section_type)
-    _rssm            = _rss.result_statistic_sections_measures.find_by!(measure: rssm.measure)
-    _tps_arms_rssm   = TpsArmsRssm.find_by!(timepoint: _eefpst1rc, extractions_extraction_forms_projects_sections_type1: _eefpst1_arm, result_statistic_sections_measure: _rssm)
+    _eefps_arm       = extraction.extractions_extraction_forms_projects_sections.find_by(extraction_forms_projects_section: a.extractions_extraction_forms_projects_section.extraction_forms_projects_section)
+    _eefps_outcome   = extraction.extractions_extraction_forms_projects_sections.find_by(extraction_forms_projects_section: result_statistic_section.population.extractions_extraction_forms_projects_sections_type1.extractions_extraction_forms_projects_section.extraction_forms_projects_section)
+    if _eefps_arm.blank? or _eefps_outcome.blank?
+      return nil
+    end
+    _eefpst1_arm     = _eefps_arm.extractions_extraction_forms_projects_sections_type1s.find_by(type1: a.type1)
+    _eefpst1_outcome = _eefps_outcome.extractions_extraction_forms_projects_sections_type1s.find_by(type1: result_statistic_section.population.extractions_extraction_forms_projects_sections_type1.type1)
+    if _eefpst1_arm.blank? or _eefpst1_outcome.blank?
+      return nil
+    end
+    _eefpst1r        = _eefpst1_outcome.extractions_extraction_forms_projects_sections_type1_rows.find_by(population_name: result_statistic_section.population.population_name)
+    if _eefpst1r.blank? then return nil end
+    _eefpst1rc       = _eefpst1r.extractions_extraction_forms_projects_sections_type1_row_columns.find_by(timepoint_name: tp.timepoint_name)
+    _rss             = _eefpst1r.result_statistic_sections.find_by(result_statistic_section_type: result_statistic_section.result_statistic_section_type)
+    if _rss.blank? then return nil end
+    _rssm            = _rss.result_statistic_sections_measures.find_by(measure: rssm.measure)
+    _tps_arms_rssm   = TpsArmsRssm.find_by(timepoint: _eefpst1rc, extractions_extraction_forms_projects_sections_type1: _eefpst1_arm, result_statistic_sections_measure: _rssm)
 
-    return Record.find_by!(recordable: _tps_arms_rssm)
+    return Record.find_by(recordable: _tps_arms_rssm)
   end
 
   def self.find_record(timepoint, extractions_extraction_forms_projects_sections_type1, result_statistic_sections_measure)

--- a/app/views/extractions/show.html.slim
+++ b/app/views/extractions/show.html.slim
@@ -6,14 +6,14 @@
 .column.row
   dl
     dt.label.primary Study
-    dd.callout.secondary = @extraction.projects_study
+    dd.callout.secondary = @extraction.citation.name
 
 .column.row
   dl
     dt.label.primary Users
     dd.callout.secondary = @extraction.projects_users_role.handle
 
-.column.row
+/.column.row
   dl
     dt.label.primary Key Questions
     dd.callout.secondary

--- a/app/views/result_statistic_sections/_rssm_form.html.slim
+++ b/app/views/result_statistic_sections/_rssm_form.html.slim
@@ -2,7 +2,10 @@ button.close-button data-close='' aria-label='Close modal' type='button'
   span aria-hidden='true' &times;
 
 h4 Please select measures to be included from the list below:
-= simple_form_for @result_statistic_section, remote: true do |f|
+= simple_form_for @result_statistic_section, remote: (if @extraction_ids.blank? then true else false end) do |f|
+  - if @extraction_ids.present?
+    = f.hidden_field :extraction_ids, value: @extraction_ids
+
   table.dependence-selector
     caption Measures
 

--- a/app/views/result_statistic_sections/consolidate/_between_arm_comparisons.html.slim
+++ b/app/views/result_statistic_sections/consolidate/_between_arm_comparisons.html.slim
@@ -75,7 +75,8 @@
                             = f.button :submit, 'Save'
 
       tr
-        td = simple_form_for @result_statistic_section do |f|
-          = f.association :measures
+        td = link_to '(edit measures)', manage_measures_result_statistic_section_path(rss_id: @result_statistic_section.id, extraction_ids: @extractions.map{|x| x.id}), remote: true
 
-          = f.submit
+.reveal#manage-measures-modal.large data-reveal='' style='min-height: 80vh'
+  button.close-button data-close='' aria-label='Close modal' type='button'
+    span aria-hidden='true' &times;

--- a/app/views/result_statistic_sections/consolidate/_descriptive_statistics.html.slim
+++ b/app/views/result_statistic_sections/consolidate/_descriptive_statistics.html.slim
@@ -41,7 +41,11 @@
                         tr
                           - if i == 0
                             td.extractor-name = extraction.user.profile.username
-                          td = TpsArmsRssm.find_record_by_extraction(extraction, a, @result_statistic_section, tp, rssm).name
+                          - tar_record = TpsArmsRssm.find_record_by_extraction(extraction, a, @result_statistic_section, tp, rssm)
+                          - if tar_record
+                            td = tar_record.name
+                          - else
+                            td
 
                       tr
                         - if i == 0
@@ -54,7 +58,8 @@
                             = f.button :submit, 'Save'
 
       tr
-        td = simple_form_for @result_statistic_section do |f|
-          = f.association :measures
+        td = link_to '(edit measures)', manage_measures_result_statistic_section_path(rss_id: @result_statistic_section.id, extraction_ids: @extractions.map{|x| x.id}), remote: true
 
-          = f.submit
+.reveal#manage-measures-modal.large data-reveal='' style='min-height: 80vh'
+  button.close-button data-close='' aria-label='Close modal' type='button'
+    span aria-hidden='true' &times;

--- a/app/views/result_statistic_sections/consolidate/_net_change.html.slim
+++ b/app/views/result_statistic_sections/consolidate/_net_change.html.slim
@@ -90,7 +90,8 @@
                 i.fi-plus>
                 | Add Within-Arm Comparison
       tr
-        td = simple_form_for @result_statistic_section do |f|
-          = f.association :measures
+        td = link_to '(edit measures)', manage_measures_result_statistic_section_path(rss_id: @result_statistic_section.id, extraction_ids: @extractions.map{|x| x.id}), remote: true
 
-          = f.submit
+.reveal#manage-measures-modal.large data-reveal='' style='min-height: 80vh'
+  button.close-button data-close='' aria-label='Close modal' type='button'
+    span aria-hidden='true' &times;

--- a/app/views/result_statistic_sections/consolidate/_within_arm_comparisons.html.slim
+++ b/app/views/result_statistic_sections/consolidate/_within_arm_comparisons.html.slim
@@ -70,7 +70,8 @@
                 | Add Comparison
 
       tr
-        td = simple_form_for @result_statistic_section do |f|
-          = f.association :measures
+        td = link_to '(edit measures)', manage_measures_result_statistic_section_path(rss_id: @result_statistic_section.id, extraction_ids: @extractions.map{|x| x.id}), remote: true
 
-          = f.submit
+.reveal#manage-measures-modal.large data-reveal='' style='min-height: 80vh'
+  button.close-button data-close='' aria-label='Close modal' type='button'
+    span aria-hidden='true' &times;

--- a/lib/tasks/remove_all_mini_extraction_eefps.rake
+++ b/lib/tasks/remove_all_mini_extraction_eefps.rake
@@ -1,0 +1,7 @@
+namespace :extraction_tasks do
+  desc "This removes all eefps that is associated with an 'Citation Screening Extraction Form' type efp"
+  task remove_all_mini_extraction_eefps: [:environment] do
+    ExtractionsExtractionFormsProjectsSection.left_joins( extraction_forms_projects_section: { extraction_forms_project: :extraction_forms_project_type } ).where(extraction_forms_projects_section: { extraction_forms_project: { extraction_forms_project_types: { name: "Citation Screening Extraction Form" } } }).destroy_all
+  end
+end
+

--- a/lib/tasks/remove_all_mini_extraction_eefps.rake
+++ b/lib/tasks/remove_all_mini_extraction_eefps.rake
@@ -4,4 +4,3 @@ namespace :extraction_tasks do
     ExtractionsExtractionFormsProjectsSection.left_joins( extraction_forms_projects_section: { extraction_forms_project: :extraction_forms_project_type } ).where(extraction_forms_projects_section: { extraction_forms_project: { extraction_forms_project_types: { name: "Citation Screening Extraction Form" } } }).destroy_all
   end
 end
-


### PR DESCRIPTION
* Descriptive statistics section no longer crashes while calling **find_record_by_extraction**
* Empty cells no longer cause alignment issues
* Updating measures redirects back to **result_statistic_sections#consolidate** instead of redirecting to **result_statistic_sections#edit**