### PR TITLE
cache API call for recently published projects

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -13,7 +13,17 @@ class StaticPagesController < ApplicationController
     end
 
     begin
-      @recently_published_projects = HTTParty.get('https://srdr.ahrq.gov/projects/api_index_published').sort_by { |a| -DateTime.parse(a[1]['publication_requested_at']).to_i }
+      url = 'https://srdr.ahrq.gov/projects/api_index_published'
+      redis = Redis.new
+      if cached_response = redis.get("GET:#{url}")
+        unparsed_response = cached_response
+      else
+        unparsed_response = HTTParty.get(url).body
+        redis.setex("GET:#{url}", 60 * 30, unparsed_response)
+      end
+      @recently_published_projects = JSON.
+        parse(unparsed_response).
+        sort_by { |a| -DateTime.parse(a[1]['publication_requested_at']).to_i }
     rescue
       @recently_published_projects = []
     end


### PR DESCRIPTION
This caching speeds up the homepage by a factor of 10 and reduces load on the other server.