### PR TITLE
Fhir

### DIFF
--- a/app/services/extraction_supplying_service.rb
+++ b/app/services/extraction_supplying_service.rb
@@ -116,197 +116,198 @@ class ExtractionSupplyingService
       questions = ExtractionFormsProjectsSectionSupplyingService.new.find_by_extraction_forms_projects_section_id(form.id)
       return if questions.blank?
 
-      eefps = {
-        'status' => status,
-        'id' => '4' + '-' + raw.id.to_s,
-        'text' => form.section_label,
-        'identifier' => [{
-          'type' => {
-            'text' => 'SRDR+ Object Identifier'
-          },
-          'system' => 'https://srdrplus.ahrq.gov/',
-          'value' => 'ExtractionsExtractionFormsProjectsSection/' + raw.id.to_s
-        }],
-        'contained' => questions,
-        'questionnaire' => '#' + questions.id,
-        'item' => []
-      }
-
+      eefpss = []
       eefpsqrcf_grouped_by_type1 = raw.extractions_extraction_forms_projects_sections_question_row_column_fields.group_by { |item| item["extractions_extraction_forms_projects_sections_type1_id"] }
       eefpsqrcf_grouped_by_type1.each do |eefps_type1_id, eefpsqrcfs|
+
+        eefps = {
+          'status' => status,
+          'id' => '4' + '-' + raw.id.to_s,
+          'text' => form.section_label,
+          'identifier' => [{
+            'type' => {
+              'text' => 'SRDR+ Object Identifier'
+            },
+            'system' => 'https://srdrplus.ahrq.gov/',
+            'value' => 'ExtractionsExtractionFormsProjectsSection/' + raw.id.to_s
+          }],
+          'contained' => questions,
+          'questionnaire' => '#' + questions.id,
+          'subject' => {},
+          'item' => []
+        }
+
         if eefps_type1_id.blank?
           next
         else
           type1 = ExtractionsExtractionFormsProjectsSectionsType1.find(eefps_type1_id).type1
           type1_display = type1.name + ' (' + type1.description + ')'
-          item_for_each_type1 = {
-            'linkId' => type1_display,
-            'text' => 'group',
-            'item' => []
+          eefps['subject'] = {
+            'reference' => 'Type1/' + type1.id.to_s,
+            'type' => 'EvidenceVariable',
+            'display' => type1_display
           }
 
-            restriction_symbol = ''
+          restriction_symbol = ''
+          for eefpsqrcf in eefpsqrcfs do
+            question_row_column_field = eefpsqrcf.question_row_column_field
+            question_row_column_id = question_row_column_field.question_row_column_id
+            question_row_column = QuestionRowColumn.find(question_row_column_id)
+            ans_form = question_row_column.question_row_columns_question_row_column_options
+            question_row_id = question_row_column.question_row_id
+            question_row = QuestionRow.find(question_row_id)
+            question_id = question_row.question_id
+            question = Question.find(question_id)
+            type = question_row_column.question_row_column_type.id
+            value = eefpsqrcf.records[0]['name']
+            if value.is_a?(String) && value.empty?
+              value = nil
+            end
 
-            for eefpsqrcf in eefpsqrcfs do
-              question_row_column_field = eefpsqrcf.question_row_column_field
-              question_row_column_id = question_row_column_field.question_row_column_id
-              question_row_column = QuestionRowColumn.find(question_row_column_id)
-              ans_form = question_row_column.question_row_columns_question_row_column_options
-              question_row_id = question_row_column.question_row_id
-              question_row = QuestionRow.find(question_row_id)
-              question_id = question_row.question_id
-              question = Question.find(question_id)
-              type = question_row_column.question_row_column_type.id
-              value = eefpsqrcf.records[0]['name']
-              if value.is_a?(String) && value.empty?
-                value = nil
+            if not eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.nil?
+              type1 = eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.type1
+            else
+              type1 = nil
+            end
+
+            if not eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.type1_type.nil?
+              type1_type = eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.type1_type
+            else
+              type1_type = nil
+            end
+
+            if value.nil?
+              if type != 9
+                next
               end
-
-              if not eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.nil?
-                type1 = eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.type1
-              else
-                type1 = nil
-              end
-
-              if not eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.type1_type.nil?
-                type1_type = eefpsqrcf.extractions_extraction_forms_projects_sections_type1&.type1_type
-              else
-                type1_type = nil
-              end
-
-              if value.nil?
-                if type != 9
-                  next
-                end
-              else
-                if type != 9
-                  item = {
-                    'linkId' => question.pos.to_s + '-' + question_id.to_s + '-' + question_row_id.to_s + '-' + question_row_column_id.to_s
-                  }
-                  if not type1.nil?
-                    item['text'] = type1.name + ' (' + type1.description + ')'
-                    if not type1_type.nil?
-                      item['text'] = item['text'] + ' (' + type1_type.name + ')'
-                    end
-                  end
-                end
-              end
-
-              followups = {}
-              for followup in raw.extractions_extraction_forms_projects_sections_followup_fields do
-                if not followup.records[0]['name'].blank?
-                  followups = followups.merge({
-                    FollowupField.find(followup.followup_field_id).question_row_columns_question_row_column_option_id => {
-                      'name' => followup.records[0]['name'],
-                      'id' => followup.followup_field_id
-                    }
-                  })
-                end
-              end
-
-              if type == 1
-                item['answer'] = {
-                  'valueString' => value
+            else
+              if type != 9
+                item = {
+                  'linkId' => question.pos.to_s + '-' + question_id.to_s + '-' + question_row_id.to_s + '-' + question_row_column_id.to_s
                 }
-                item_for_each_type1['item'].append(item)
-              elsif type == 2
-                if /-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?/.match(value)
-                  item['answer'] = {
-                    'valueDecimal' => value
-                  }
-                  item_for_each_type1['item'].append(item)
-                  unless restriction_symbol.empty?
-                    symbol_item = {
-                      'linkId' => question.pos.to_s + '-' + question_id.to_s + '-' + question_row_id.to_s + '-' + question_row_column_id.to_s,
-                      'answer' => {
-                        'valueString' => restriction_symbol
-                      }
-                    }
-                    item_for_each_type1['item'].append(symbol_item)
-                  end
-                  restriction_symbol = ''
-                else
-                  restriction_symbol = value
-                end
-              elsif type == 5
-                matches = value.scan(/\D*(\d+)\D*/)
-                for match in matches do
-                  checkbox_id = match[0].to_i
-                  name = ans_form.find(checkbox_id)['name']
-                  item['answer'] = {
-                    'valueString' => name
-                  }
-
-                  if followups.has_key?(checkbox_id)
-                    followup_item = {}
-                    followup_item['linkId'] = item['linkId'] + '-' + followups[checkbox_id]['id'].to_s
-                    followup_item['answer'] = {
-                      'valueString' => followups[checkbox_id]['name']
-                    }
-                    item['item'] = followup_item
-                  else
-                    item['item'] = []
-                  end
-
-                  item_for_each_type1['item'].append(item.dup)
-                end
-              elsif type == 6
-                name = ans_form.find(value)['name']
-                item['answer'] = {
-                  'valueString' => name
-                }
-                item_for_each_type1['item'].append(item)
-              elsif type == 7
-                name = ans_form.find(value)['name']
-                item['answer'] = {
-                  'valueString' => name
-                }
-                item_for_each_type1['item'].append(item)
-                if followups.has_key?(value.to_i)
-                  followup_item = {}
-                  followup_item['linkId'] = item['linkId'] + '-' + followups[value.to_i]['id'].to_s
-                  followup_item['answer'] = {
-                    'valueString' => followups[value.to_i]['name']
-                  }
-                  item_for_each_type1['item'].append(followup_item)
-                end
-              elsif type == 8
-                name = ans_form.find(value)['name']
-                item['answer'] = {
-                  'valueString' => name
-                }
-                item_for_each_type1['item'].append(item)
-              elsif type == 9
-                if not type1.nil?
-                  item_text = type1.name + ' (' + type1.description + ')'
-                  if not type1_type.nil?
-                    item_text = item['text'] + ' (' + type1_type.name + ')'
-                  end
-                end
-                for dicts in eefpsqrcf.extractions_extraction_forms_projects_sections_question_row_column_fields_question_row_columns_question_row_column_options do
-                  item = {
-                    'linkId' => question.pos.to_s + '-' + question_id.to_s + '-' + question_row_id.to_s + '-' + question_row_column_id.to_s
-                  }
-                  item['text'] = item_text
-                  value = dicts.question_row_columns_question_row_column_option_id
-                  name = ans_form.find(value)['name']
-                  item['answer'] = {
-                    'valueString' => name
-                  }
-                  item_for_each_type1['item'].append(item)
-                end
-                item = {}
               end
             end
 
-          eefps['item'].append(item_for_each_type1)
+            followups = {}
+            for followup in raw.extractions_extraction_forms_projects_sections_followup_fields do
+              if not followup.records[0]['name'].blank?
+                followups = followups.merge({
+                  FollowupField.find(followup.followup_field_id).question_row_columns_question_row_column_option_id => {
+                    'name' => followup.records[0]['name'],
+                    'id' => followup.followup_field_id
+                  }
+                })
+              end
+            end
+
+            if type == 1
+              item['answer'] = {
+                'valueString' => value
+              }
+              eefps['item'].append(item)
+            elsif type == 2
+              if /-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?/.match(value)
+                item['answer'] = {
+                  'valueDecimal' => value
+                }
+                eefps['item'].append(item)
+                unless restriction_symbol.empty?
+                  symbol_item = {
+                    'linkId' => question.pos.to_s + '-' + question_id.to_s + '-' + question_row_id.to_s + '-' + question_row_column_id.to_s,
+                    'answer' => {
+                      'valueString' => restriction_symbol
+                    }
+                  }
+                  eefps['item'].append(symbol_item)
+                end
+                restriction_symbol = ''
+              else
+                restriction_symbol = value
+              end
+            elsif type == 5
+              matches = value.scan(/\D*(\d+)\D*/)
+              for match in matches do
+                checkbox_id = match[0].to_i
+                name = ans_form.find(checkbox_id)['name']
+                item['answer'] = {
+                  'valueString' => name
+                }
+
+                if followups.has_key?(checkbox_id)
+                  followup_item = {}
+                  followup_item['linkId'] = item['linkId'] + '-' + followups[checkbox_id]['id'].to_s
+                  followup_item['answer'] = {
+                    'valueString' => followups[checkbox_id]['name']
+                  }
+                  item['item'] = followup_item
+                else
+                  item['item'] = []
+                end
+
+                eefps['item'].append(item.dup)
+              end
+            elsif type == 6
+              name = ans_form.find(value)['name']
+              item['answer'] = {
+                'valueString' => name
+              }
+              eefps['item'].append(item)
+            elsif type == 7
+              name = ans_form.find(value)['name']
+              item['answer'] = {
+                'valueString' => name
+              }
+              eefps['item'].append(item)
+              if followups.has_key?(value.to_i)
+                followup_item = {}
+                followup_item['linkId'] = item['linkId'] + '-' + followups[value.to_i]['id'].to_s
+                followup_item['answer'] = {
+                  'valueString' => followups[value.to_i]['name']
+                }
+                eefps['item'].append(followup_item)
+              end
+            elsif type == 8
+              name = ans_form.find(value)['name']
+              item['answer'] = {
+                'valueString' => name
+              }
+              eefps['item'].append(item)
+            elsif type == 9
+              for dicts in eefpsqrcf.extractions_extraction_forms_projects_sections_question_row_column_fields_question_row_columns_question_row_column_options do
+                item = {
+                  'linkId' => question.pos.to_s + '-' + question_id.to_s + '-' + question_row_id.to_s + '-' + question_row_column_id.to_s
+                }
+                value = dicts.question_row_columns_question_row_column_option_id
+                name = ans_form.find(value)['name']
+                item['answer'] = {
+                  'valueString' => name
+                }
+                eefps['item'].append(item)
+              end
+              item = {}
+            end
+          end
+
+          if eefps['item'].empty?
+            next
+          end
+
+          eefpss.append(FHIR::QuestionnaireResponse.new(eefps))
         end
       end
 
-      if eefps['item'].empty?
+      if eefpss.empty?
         return
       end
-      return FHIR::QuestionnaireResponse.new(eefps)
+
+      link_info = [
+        {
+          'relation' => 'service-doc',
+          'url' => 'doc/fhir/questionnaire_response_group_by_type1.txt'
+        }
+      ]
+      return create_bundle(objs=eefpss, type='collection', link_info=link_info)
+
     elsif form.extraction_forms_projects_section_type_id == 3
       extraction = Extraction.find(raw.extraction_id)
       project = Project.find(extraction.project_id)

--- a/app/services/extraction_supplying_service.rb
+++ b/app/services/extraction_supplying_service.rb
@@ -341,19 +341,23 @@ class ExtractionSupplyingService
                   measure_name = Measure.find(result_statistic_sections_measure.measure_id)['name']
                   for tps_arms_rssm in result_statistic_sections_measure.tps_arms_rssms do
                     record = tps_arms_rssm.records[0]
-                    if record.nil?
+                    if record.blank?
                       next
                     else
-                      record = record['name']
+                      if record['name'].blank?
+                        next
+                      else
+                        record = record['name']
+                      end
                     end
                     record_id = tps_arms_rssm.records[0]['id']
                     time_point = ExtractionsExtractionFormsProjectsSectionsType1RowColumn.find_by(id: tps_arms_rssm.timepoint_id)
-                    if time_point.nil?
+                    if time_point.blank?
                       next
                     end
                     time_point_name = time_point.timepoint_name['name'] + ' ' + time_point.timepoint_name['unit']
                     arm = ExtractionsExtractionFormsProjectsSectionsType1.find_by(id: tps_arms_rssm.extractions_extraction_forms_projects_sections_type1_id)
-                    if arm.nil?
+                    if arm.blank?
                       next
                     end
                     arm_name = Type1.find(arm.type1_id)['name']
@@ -377,19 +381,23 @@ class ExtractionSupplyingService
                   measure_name = Measure.find(result_statistic_sections_measure.measure_id)['name']
                   for tps_comparisons_rssm in result_statistic_sections_measure.tps_comparisons_rssms do
                     record = tps_comparisons_rssm.records[0]
-                    if record.nil?
+                    if record.blank?
                       next
                     else
-                      record = record['name']
+                      if record['name'].blank?
+                        next
+                      else
+                        record = record['name']
+                      end
                     end
                     record_id = tps_comparisons_rssm.records[0]['id']
                     time_point = ExtractionsExtractionFormsProjectsSectionsType1RowColumn.find_by(id: tps_comparisons_rssm.timepoint_id)
-                    if time_point.nil?
+                    if time_point.blank?
                       next
                     end
                     time_point_name = time_point.timepoint_name['name'] + ' ' + time_point.timepoint_name['unit']
                     comparison = Comparison.find_by(id: tps_comparisons_rssm.comparison_id)
-                    if comparison.nil?
+                    if comparison.blank?
                       next
                     end
                     arm_names = []
@@ -417,14 +425,18 @@ class ExtractionSupplyingService
                   measure_name = Measure.find(result_statistic_sections_measure.measure_id)['name']
                   for comparisons_arms_rssm in result_statistic_sections_measure.comparisons_arms_rssms do
                     record = comparisons_arms_rssm.records[0]
-                    if record.nil?
+                    if record.blank?
                       next
                     else
-                      record = record['name']
+                      if record['name'].blank?
+                        next
+                      else
+                        record = record['name']
+                      end
                     end
                     record_id = comparisons_arms_rssm.records[0]['id']
                     comparison = Comparison.find_by(id: comparisons_arms_rssm.comparison_id)
-                    if comparison.nil?
+                    if comparison.blank?
                       next
                     end
                     time_point_names = []
@@ -435,7 +447,7 @@ class ExtractionSupplyingService
                       time_point_names.append(time_point_name)
                     end
                     arm = ExtractionsExtractionFormsProjectsSectionsType1.find_by(id: comparisons_arms_rssm.extractions_extraction_forms_projects_sections_type1_id)
-                    if arm.nil?
+                    if arm.blank?
                       next
                     end
                     arm_name = Type1.find(arm.type1_id)['name']
@@ -459,15 +471,19 @@ class ExtractionSupplyingService
                   measure_name = Measure.find(result_statistic_sections_measure.measure_id)['name']
                   for wacs_bacs_rssm in result_statistic_sections_measure.wacs_bacs_rssms do
                     record = wacs_bacs_rssm.records[0]
-                    if record.nil?
+                    if record.blank?
                       next
                     else
-                      record = record['name']
+                      if record['name'].blank?
+                        next
+                      else
+                        record = record['name']
+                      end
                     end
                     record_id = wacs_bacs_rssm.records[0]['id']
 
                     comparison_arm = Comparison.find_by(id: wacs_bacs_rssm.bac_id)
-                    if comparison_arm.nil?
+                    if comparison_arm.blank?
                       next
                     end
                     arm_names = []
@@ -477,7 +493,7 @@ class ExtractionSupplyingService
                     end
 
                     comparison_time_point = Comparison.find_by(id: wacs_bacs_rssm.wac_id)
-                    if comparison_time_point.nil?
+                    if comparison_time_point.blank?
                       next
                     end
                     time_point_names = []
@@ -507,14 +523,18 @@ class ExtractionSupplyingService
           end
         end
 
-        if evidences.empty?
+        if evidences.blank?
           return
         else
+          merged_evidences = merge_evidence_by_variable_definition(evidences)
+          merged_evidences = merged_evidences.map do |element|
+            FHIR::Evidence.new(element)
+          end
           link_info_evidence = [{
             'relation' => 'service-doc',
             'url' => 'doc/fhir/extraction.txt'
           }]
-          return create_bundle(fhir_objs=evidences, type='collection', link_info=link_info_evidence)
+          return create_bundle(fhir_objs=merged_evidences, type='collection', link_info=link_info_evidence)
         end
 
       else
@@ -545,19 +565,23 @@ class ExtractionSupplyingService
                 measure_name = Measure.find(result_statistic_sections_measure.measure_id)['name']
                 for tps_comparisons_rssm in result_statistic_sections_measure.tps_comparisons_rssms do
                   record = tps_comparisons_rssm.records[0]
-                  if record.nil?
+                  if record.blank?
                     next
                   else
-                    record = record['name']
+                    if record['name'].blank?
+                      next
+                    else
+                      record = record['name']
+                    end
                   end
                   record_id = tps_comparisons_rssm.records[0]['id']
                   time_point = ExtractionsExtractionFormsProjectsSectionsType1RowColumn.find_by(id: tps_comparisons_rssm.timepoint_id)
-                  if time_point.nil?
+                  if time_point.blank?
                     next
                   end
                   time_point_name = time_point.timepoint_name['name'] + ' ' + time_point.timepoint_name['unit']
                   comparison = Comparison.find_by(id: tps_comparisons_rssm.comparison_id)
-                  if comparison.nil?
+                  if comparison.blank?
                     next
                   end
                   arm_names = []
@@ -584,17 +608,46 @@ class ExtractionSupplyingService
           end
         end
 
-        if evidences.empty?
+        if evidences.blank?
           return
         else
+          merged_evidences = merge_evidence_by_variable_definition(evidences)
+          merged_evidences = merged_evidences.map do |element|
+            FHIR::Evidence.new(element)
+          end
           link_info_evidence = [{
             'relation' => 'service-doc',
             'url' => 'doc/fhir/extraction.txt'
           }]
-          return create_bundle(fhir_objs=evidences, type='collection', link_info=link_info_evidence)
+          return create_bundle(fhir_objs=merged_evidences, type='collection', link_info=link_info_evidence)
         end
       end
     end
+  end
+
+  def merge_evidence_by_variable_definition(evidences)
+    grouped_evidences = evidences.group_by { |e| e['variableDefinition'].to_json }
+
+    merged_evidences = []
+
+    grouped_evidences.each do |_, group|
+      merged_resource = group.first.deep_dup
+
+      group[1..-1].each do |resource|
+        if resource['id'] && resource['statistic'] && resource['identifier']
+          merged_resource['id'] += "-#{resource['id'].split('-').last}"
+          merged_resource['statistic'] += resource['statistic']
+
+          if resource['identifier'].first && resource['identifier'].first['value']
+            merged_resource['identifier'].first['value'] += "-#{resource['identifier'].first['value'].split('/').last}"
+          end
+        end
+      end
+
+      merged_evidences << merged_resource
+    end
+
+    merged_evidences
   end
 
   def get_evidence_obj(
@@ -768,6 +821,6 @@ class ExtractionSupplyingService
       }
     end
 
-    return FHIR::Evidence.new(evidence)
+    return evidence
   end
 end

--- a/public/doc/fhir/questionnaire_response_group_by_type1.txt
+++ b/public/doc/fhir/questionnaire_response_group_by_type1.txt
@@ -1,0 +1,1 @@
+In this bundle, there are numerous QuestionnaireResponses, each belonging to a different Type1 and answering the same Questionnaire. Type1 refers to potential intervention measures, outcomes, or other user-defined items.


### PR DESCRIPTION
Change QuestionnaireResponse structure
- Group answers by type1 using subject instead of nested items
- Remove type1 information inside item

Change Evidence structure
- Group Evidence with same variableRole
- Change Evidence id and identifier representation, ex:
  "id": "5-5714491-5-5714493" combines two records(5714491 5714493)
  Record/5714491-5714493 is the same.