### PR TITLE
Bugfix: ML related pipeline

### DIFF
--- a/app/services/auto_training_service.rb
+++ b/app/services/auto_training_service.rb
@@ -42,6 +42,10 @@ class AutoTrainingService
             else
               retries += 1
             end
+
+            if retries >= MAX_RETRIES && ml_model
+              ml_model.destroy
+            end
           end
 
           project.update(force_training: false)

--- a/app/services/machine_learning_statistic_service.rb
+++ b/app/services/machine_learning_statistic_service.rb
@@ -11,8 +11,10 @@ class MachineLearningStatisticService
 
     unscreened_scores = MlPrediction.joins("LEFT JOIN citations_projects ON citations_projects.id = ml_predictions.citations_project_id")
                                     .joins("LEFT JOIN abstract_screening_results ON abstract_screening_results.citations_project_id = citations_projects.id")
+                                    .joins("LEFT JOIN screening_qualifications ON screening_qualifications.citations_project_id = citations_projects.id")
                                     .where("ml_predictions.ml_model_id = ?", latest_ml_model.id)
                                     .where("abstract_screening_results.id IS NULL")
+                                    .where("screening_qualifications.id IS NULL")
                                     .pluck(:score)
 
     unscreened_scores

--- a/app/services/robot_screen_service.rb
+++ b/app/services/robot_screen_service.rb
@@ -58,7 +58,15 @@ class RobotScreenService
     total_predictions = predictions.size
     high_score_count = predictions.count { |score| score >= score_threshold }
     percentage = (high_score_count.to_f / total_predictions) * 100
-    percentage < percentage_threshold
+
+    mean_score = predictions.sum.to_f / total_predictions
+    std_dev = Math.sqrt(predictions.map { |score| (score - mean_score) ** 2 }.sum / total_predictions)
+
+    if mean_score < 0.05
+      true
+    else
+      percentage < percentage_threshold && std_dev > 0.01
+    end
   end
 
   def save_predictions(data, predictions, ml_model)


### PR DESCRIPTION
- Prevent score from centralizing

- Fix error when retries exceed maximun

- Exclude screening qualification from unscreened predictions